### PR TITLE
Reproducing SWF-1566

### DIFF
--- a/SWF-1566/pom.xml
+++ b/SWF-1566/pom.xml
@@ -1,0 +1,250 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.springframework.webflow.issues</groupId>
+	<artifactId>SWF-1566</artifactId>
+	<version>1.0-SNAPSHOT</version>
+	<name>Spring Web Flow Issue Reproduction Project</name>
+	<packaging>war</packaging>
+
+	<properties>
+		<java-version>1.6</java-version>
+		<org.springwebflow-version>2.4.0.BUILD-SNAPSHOT</org.springwebflow-version>
+		<org.springframework-version>3.1.1.RELEASE</org.springframework-version>
+		<org.springsecurity-version>3.0.7.RELEASE</org.springsecurity-version>
+		<org.slf4j-version>1.6.1</org.slf4j-version>
+	</properties>
+
+	<dependencies>
+		<!-- Spring Framework -->
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context</artifactId>
+			<version>${org.springframework-version}</version>
+			<exclusions>
+				<!-- Exclude Commons Logging in favor of SLF4j -->
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-webmvc</artifactId>
+			<version>${org.springframework-version}</version>
+		</dependency>
+
+        <!-- Spring Web Flow -->
+		<dependency>
+			<groupId>org.springframework.webflow</groupId>
+			<artifactId>spring-webflow</artifactId>
+			<version>${org.springwebflow-version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.webflow</groupId>
+			<artifactId>spring-js</artifactId>
+			<version>${org.springwebflow-version}</version>
+		</dependency>
+        <!-- Spring Security
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-web</artifactId>
+			<version>${org.springsecurity-version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				 </exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-taglibs</artifactId>
+			<version>${org.springsecurity-version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-config</artifactId>
+			<version>${org.springsecurity-version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				 </exclusion>
+			</exclusions>
+        </dependency>
+        -->
+
+		<!-- Logging -->
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>${org.slf4j-version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>jcl-over-slf4j</artifactId>
+			<version>${org.slf4j-version}</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-log4j12</artifactId>
+			<version>${org.slf4j-version}</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>log4j</groupId>
+			<artifactId>log4j</artifactId>
+			<version>1.2.16</version>
+			<scope>runtime</scope>
+		</dependency>
+
+		<!-- Servlet API, JSP API, JSTL -->
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>servlet-api</artifactId>
+			<version>2.5</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>javax.servlet.jsp</groupId>
+			<artifactId>jsp-api</artifactId>
+			<version>2.1</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>jstl</artifactId>
+			<version>1.2</version>
+		</dependency>
+
+		<!-- Apache Tiles
+		<dependency>
+			<groupId>org.apache.tiles</groupId>
+			<artifactId>tiles-jsp</artifactId>
+			<version>2.1.3</version>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging-api</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		-->
+
+		<!-- Bean Validation with the Hibernate Validator -->
+		<dependency>
+			<groupId>javax.validation</groupId>
+			<artifactId>validation-api</artifactId>
+			<version>1.0.0.GA</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-validator</artifactId>
+			<version>4.1.0.Final</version>
+		</dependency>
+
+		<!-- JAXB (for Hibernate Validator with Java 1.5)
+        <dependency>
+          <groupId>javax.xml.bind</groupId>
+          <artifactId>jaxb-api</artifactId>
+          <version>2.1</version>
+        </dependency>
+		-->
+
+		<!-- Joda Time
+		<dependency>
+			<groupId>joda-time</groupId>
+			<artifactId>joda-time</artifactId>
+			<version>1.6.2</version>
+		</dependency>
+		<dependency>
+			<groupId>joda-time</groupId>
+			<artifactId>joda-time-jsptags</artifactId>
+			<version>1.0.2</version>
+			<scope>runtime</scope>
+		</dependency>
+		-->
+
+		<!-- JUnit -->
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.8</version>
+			<scope>test</scope>
+		</dependency>
+
+	</dependencies>
+
+	<repositories>
+
+		<repository>
+			<id>spring-related-snapshot-releases</id>
+			<name>Spring Maven Snapshot Repository</name>
+			<url>http://maven.springframework.org/snapshot</url>
+			<releases><enabled>false</enabled></releases>
+			<snapshots><enabled>true</enabled></snapshots>
+		</repository>
+
+        <repository>
+			<id>spring-related-milestone-releases</id>
+			<name>Spring Maven Milestone Repository</name>
+			<url>http://maven.springframework.org/milestone</url>
+			<snapshots><enabled>false</enabled></snapshots>
+		</repository>
+
+	</repositories>
+
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>${java-version}</source>
+					<target>${java-version}</target>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>install</id>
+						<phase>install</phase>
+						<goals>
+							<goal>sources</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<includes>
+						<include>**/*Tests.java</include>
+					</includes>
+					<excludes>
+						<exclude>**/*Abstract*.java</exclude>
+					</excludes>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-eclipse-plugin</artifactId>
+				<version>2.8</version>
+				<configuration>
+					<downloadSources>true</downloadSources>
+					<downloadJavadocs>false</downloadJavadocs>
+					<wtpversion>2.0</wtpversion>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>
+

--- a/SWF-1566/src/main/java/foo/bar/ElementBean.java
+++ b/SWF-1566/src/main/java/foo/bar/ElementBean.java
@@ -1,0 +1,21 @@
+package foo.bar;
+
+import java.io.Serializable;
+
+public class ElementBean implements Serializable{
+	private String a;
+	private String b;
+	public String getA() {
+		return a;
+	}
+	public void setA(String a) {
+		this.a = a;
+	}
+	public String getB() {
+		return b;
+	}
+	public void setB(String b) {
+		this.b = b;
+	}
+	
+}

--- a/SWF-1566/src/main/java/foo/bar/HighLevelBean.java
+++ b/SWF-1566/src/main/java/foo/bar/HighLevelBean.java
@@ -1,0 +1,22 @@
+package foo.bar;
+
+import java.io.Serializable;
+import java.util.LinkedList;
+import java.util.List;
+
+public class HighLevelBean implements Serializable {
+	private List<ElementBean> elements = new LinkedList<ElementBean>();
+
+	public List<ElementBean> getElements() {
+		return elements;
+	}
+
+	public void setElements(List<ElementBean> elements) {
+		this.elements = elements;
+	}
+
+	public HighLevelBean() {
+		elements.add(new ElementBean());
+	}
+
+}

--- a/SWF-1566/src/main/resources/log4j.properties
+++ b/SWF-1566/src/main/resources/log4j.properties
@@ -1,0 +1,10 @@
+log4j.rootCategory=INFO, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d %p [%c] - <%m>%n
+
+log4j.category.org.springframework.binding=DEBUG
+log4j.category.org.springframework.web=DEBUG
+log4j.category.org.springframework.webflow=DEBUG
+log4j.category.org.springframework.js=DEBUG

--- a/SWF-1566/src/main/webapp/WEB-INF/myflow/myflow.xml
+++ b/SWF-1566/src/main/webapp/WEB-INF/myflow/myflow.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<flow xmlns="http://www.springframework.org/schema/webflow"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="
+		http://www.springframework.org/schema/webflow
+		http://www.springframework.org/schema/webflow/spring-webflow-2.0.xsd">
+	<on-start>
+		<set name="flowScope.myBean" value="new foo.bar.HighLevelBean()"/>
+	</on-start>
+
+	<view-state id="view" model="myBean" >
+		<transition on="continue" to="show" />
+	</view-state>
+	
+	<view-state id="show" model="myBean" >
+		<transition on="continue" to="done" />
+	</view-state>
+
+	<end-state id="done" view="externalRedirect:contextRelative:/" />
+
+</flow>

--- a/SWF-1566/src/main/webapp/WEB-INF/myflow/show.jsp
+++ b/SWF-1566/src/main/webapp/WEB-INF/myflow/show.jsp
@@ -1,0 +1,33 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+	pageEncoding="UTF-8"%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
+<%@ taglib prefix="form" uri="http://www.springframework.org/tags/form"%>
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>My Flow Page</title>
+</head>
+<body>
+	<h1>My Flow Page</h1>
+	<hr>
+		<table border="1">
+			<thead>
+				<tr>
+					<td>index</td>
+					<td>a</td>
+					<td>b</td>
+				</tr>
+			</thead>
+		<c:forEach items="${myBean.elements}" varStatus="status" var="elem">
+			<tr>
+				<td>${status.index}</td>
+				<td>${elem.a}</td>
+				<td>${elem.b}</td>
+			</tr>	
+		</c:forEach>
+		</table>
+	<a href="${flowExecutionUrl}&_eventId=continue">endFlow</a>
+</body>
+</html>

--- a/SWF-1566/src/main/webapp/WEB-INF/myflow/view.jsp
+++ b/SWF-1566/src/main/webapp/WEB-INF/myflow/view.jsp
@@ -1,0 +1,32 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+	pageEncoding="UTF-8"%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
+<%@ taglib prefix="form" uri="http://www.springframework.org/tags/form"%>
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>My Flow Page</title>
+</head>
+<body>
+	<h1>My Flow Page</h1>
+	<hr>
+	<form:form modelAttribute="myBean" method="POST"
+		action="${flowExecutionUrl}">
+		
+		<ul>
+					<c:forEach items="${myBean.elements}" varStatus="status">
+						<li>							
+							<form:input path="elements[${status.index}].a" />
+							<form:input path="elements[${status.index}].b" />
+						</li>
+					</c:forEach>
+		</ul>
+		
+		<p>
+			<button type="submit" name="_eventId_continue">Next</button>
+		</p>
+	</form:form>
+</body>
+</html>

--- a/SWF-1566/src/main/webapp/WEB-INF/spring/root-context.xml
+++ b/SWF-1566/src/main/webapp/WEB-INF/spring/root-context.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="
+		http://www.springframework.org/schema/beans
+		http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+
+	<!-- Root Context: defines shared resources visible to all other web components -->
+
+</beans>

--- a/SWF-1566/src/main/webapp/WEB-INF/spring/servlet-context.xml
+++ b/SWF-1566/src/main/webapp/WEB-INF/spring/servlet-context.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:mvc="http://www.springframework.org/schema/mvc"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xsi:schemaLocation="
+		http://www.springframework.org/schema/beans
+		http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/context
+		http://www.springframework.org/schema/context/spring-context-3.0.xsd
+		http://www.springframework.org/schema/mvc
+		http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd">
+
+	<context:component-scan base-package="org.springframework.webflow.issues" />
+
+	<!--
+		Map request paths to flows in the flowRegistry;
+		For example a path of /phonebook looks for a flow with id "phonebook".
+		-->
+	<bean class="org.springframework.webflow.mvc.servlet.FlowHandlerMapping">
+		<property name="order" value="-1"/>
+		<property name="flowRegistry" ref="flowRegistry" />
+	</bean>
+
+	<!-- Enable processing of requests by annotated Spring MVC @Controllers -->
+	<mvc:annotation-driven/>
+
+	<mvc:resources mapping="/resources/**" location="/, classpath:/META-INF/web-resources/" />
+	<mvc:default-servlet-handler />
+
+	<!-- Map paths directly to view names without controller processing. Use the view-name attribute if necessary: by convention the view name equals the path without the leading slash -->
+	<mvc:view-controller path="/" view-name="home" />
+
+	<!-- Resolve view names to JSP pages under /WEB-INF/views -->
+	<bean class="org.springframework.web.servlet.view.InternalResourceViewResolver">
+		<property name="prefix" value="/WEB-INF/views/" />
+		<property name="suffix" value=".jsp" />
+	</bean>
+
+	<!--
+		Uncomment to resolve logical view names returned to Tiles definitions
+		Also remember to remove the InternalResourceViewResolver above
+
+	<bean id="tilesViewResolver" class="org.springframework.js.ajax.AjaxUrlBasedViewResolver">
+		<property name="viewClass" value="org.springframework.webflow.mvc.view.FlowAjaxTilesView"/>
+	</bean>
+
+	<bean id="tilesConfigurer" class="org.springframework.web.servlet.view.tiles2.TilesConfigurer">
+		<property name="definitions">
+			<list>
+				<value>/WEB-INF/**/views.xml</value>
+			</list>
+		</property>
+	</bean>
+	-->
+
+	<!-- Enable FlowExecutor invocation by the DispatcherServlet -->
+	<bean class="org.springframework.webflow.mvc.servlet.FlowHandlerAdapter">
+		<property name="flowExecutor" ref="flowExecutor"/>
+	</bean>
+
+	<!-- Import Spring Web Flow specific configuration -->
+	<import resource="webflow.xml"/>
+
+</beans>

--- a/SWF-1566/src/main/webapp/WEB-INF/spring/webflow.xml
+++ b/SWF-1566/src/main/webapp/WEB-INF/spring/webflow.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:webflow="http://www.springframework.org/schema/webflow-config"
+       xsi:schemaLocation="
+           http://www.springframework.org/schema/beans
+           http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+           http://www.springframework.org/schema/webflow-config
+           http://www.springframework.org/schema/webflow-config/spring-webflow-config-2.3.xsd">
+
+	<!-- Executes flows: the entry point into the Spring Web Flow system -->
+	<webflow:flow-executor id="flowExecutor"/>
+
+	<!-- The registry of executable flow definitions -->
+	<webflow:flow-registry id="flowRegistry" flow-builder-services="flowBuilderServices" base-path="/WEB-INF">
+		<webflow:flow-location-pattern value="/**/*flow.xml" />
+	</webflow:flow-registry>
+
+	<!-- Plugs in a custom creator for Web Flow views -->
+	<webflow:flow-builder-services id="flowBuilderServices" development="true" validator="validator"  expression-parser="webflowExpressionParser"/>
+	
+	<bean id="expressionParser" class="org.springframework.expression.spel.standard.SpelExpressionParser">
+    <constructor-arg name="configuration">
+      <bean class="org.springframework.expression.spel.SpelParserConfiguration">
+        <constructor-arg name="autoGrowCollections" value="true" />
+        <constructor-arg name="autoGrowNullReferences" value="true" />
+      </bean>
+    </constructor-arg>
+  </bean>
+
+  <bean id="webflowExpressionParser" class="org.springframework.webflow.expression.spel.WebFlowSpringELExpressionParser">
+    <constructor-arg name="expressionParser" ref="expressionParser" />    
+  </bean>
+	
+
+	<!-- Bootstraps JSR-303 validation and exposes it through Spring's Validator interface -->
+	<bean id="validator" class="org.springframework.validation.beanvalidation.LocalValidatorFactoryBean"/>
+
+	<!-- Apache Tiles:
+		 Also reference it from <webflow:flow-builder-services> above
+
+	<bean id="mvcViewFactoryCreator" class="org.springframework.webflow.mvc.builder.MvcViewFactoryCreator">
+		<property name="viewResolvers" ref="tilesViewResolver"/>
+		<property name="useSpringBeanBinding" value="true" />
+	</bean>
+	-->
+
+	<!-- Spring Security:
+		 Also add it as a listener as a sub-element of <webflow:flow-executor> above
+
+	<bean id="securityFlowExecutionListener" class="org.springframework.webflow.security.SecurityFlowExecutionListener" />
+	-->
+
+</beans>

--- a/SWF-1566/src/main/webapp/WEB-INF/views/home.jsp
+++ b/SWF-1566/src/main/webapp/WEB-INF/views/home.jsp
@@ -1,0 +1,16 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>Home</title>
+</head>
+<body>
+  <h1>Home</h1>
+  <p><strong>See server log for debug information</strong></p>
+  <hr>
+  <p><a href="myflow">Start Flow</a></p>
+</body>
+</html>

--- a/SWF-1566/src/main/webapp/WEB-INF/web.xml
+++ b/SWF-1566/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+
+	<context-param>
+		<param-name>contextConfigLocation</param-name>
+		<param-value>/WEB-INF/spring/root-context.xml</param-value>
+	</context-param>
+
+	<listener>
+		<listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>
+	</listener>
+
+	<!-- Spring Security
+	<filter>
+		<filter-name>springSecurityFilterChain</filter-name>
+		<filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>
+		</filter>
+
+		<filter-mapping>
+			<filter-name>springSecurityFilterChain</filter-name>
+			<servlet-name>appServlet</servlet-name>
+		</filter-mapping>
+	-->
+
+	<servlet>
+		<servlet-name>appServlet</servlet-name>
+		<servlet-class>org.springframework.web.servlet.DispatcherServlet</servlet-class>
+		<init-param>
+			<param-name>contextConfigLocation</param-name>
+			<param-value>/WEB-INF/spring/servlet-context.xml</param-value>
+		</init-param>
+		<load-on-startup>1</load-on-startup>
+	</servlet>
+
+	<servlet-mapping>
+		<servlet-name>appServlet</servlet-name>
+		<url-pattern>/</url-pattern>
+	</servlet-mapping>
+
+	<!--
+		Disables Servlet Container welcome file handling.
+		Needed for compatibility with Servlet 3.0 and Tomcat 7.0
+		-->
+	<welcome-file-list>
+		<welcome-file></welcome-file>
+	</welcome-file-list>
+
+</web-app>

--- a/SWF-1566/src/test/java/org/springframework/webflow/issues/MyFlowExecutionTests.java
+++ b/SWF-1566/src/test/java/org/springframework/webflow/issues/MyFlowExecutionTests.java
@@ -1,0 +1,58 @@
+package org.springframework.webflow.issues;
+
+import org.springframework.webflow.config.FlowDefinitionResource;
+import org.springframework.webflow.config.FlowDefinitionResourceFactory;
+import org.springframework.webflow.core.collection.LocalAttributeMap;
+import org.springframework.webflow.test.MockExternalContext;
+import org.springframework.webflow.test.MockFlowBuilderContext;
+import org.springframework.webflow.test.MockParameterMap;
+import org.springframework.webflow.test.execution.AbstractXmlFlowExecutionTests;
+
+import foo.bar.HighLevelBean;
+
+public class MyFlowExecutionTests extends AbstractXmlFlowExecutionTests {
+
+	@Override
+	protected FlowDefinitionResource getResource(FlowDefinitionResourceFactory resourceFactory) {
+		return resourceFactory.createFileResource("src/main/webapp/WEB-INF/myflow/myflow.xml");
+	}
+
+	@Override
+	protected void configureFlowBuilderContext(MockFlowBuilderContext builderContext) {
+		// Register beans here..
+		// MyService myService = ... ;
+		// builderContext.registerBean("myService", myService);
+	}
+
+	public void testStartFlow() {
+
+		MockExternalContext context = new MockExternalContext();
+
+		startFlow(new LocalAttributeMap(), context);
+
+		assertCurrentStateEquals("view");
+		assertResponseWrittenEquals("view", context);
+	}
+
+	public void testEndFlow() {
+		setCurrentState("view");
+
+		getFlowScope().put("myBean", new HighLevelBean());
+		
+		MockExternalContext context = new MockExternalContext();
+		MockParameterMap mockParameterMap = new MockParameterMap();
+		mockParameterMap.put("elements[12131200321321300].a", "aaaa");
+				
+		context.setRequestParameterMap(mockParameterMap);
+		context.setEventId("continue");
+		resumeFlow(context);
+
+		MockExternalContext context2 = new MockExternalContext();
+		context2.setEventId("continue");
+		resumeFlow(context2);
+		
+		assertFlowExecutionEnded();
+		assertFlowExecutionOutcomeEquals("done");
+	}
+
+}

--- a/SWF-1566/src/test/resources/log4j.properties
+++ b/SWF-1566/src/test/resources/log4j.properties
@@ -1,0 +1,10 @@
+log4j.rootCategory=INFO, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d %p [%c] - <%m>%n
+
+log4j.category.org.springframework.binding=DEBUG
+log4j.category.org.springframework.web=DEBUG
+log4j.category.org.springframework.webflow=DEBUG
+log4j.category.org.springframework.js=DEBUG


### PR DESCRIPTION
Hi 

As suggested by Phil, this is a sample SWF project to reproduce issue SWF-1566. 
Unfortunately i have no time to provide you an automated test to uncover the issue, since SWF testing machinery (AbstractXmlFlowExecutionTests) does not implement data binding: MockViewFactoryCreator#MockView#processUserEvent method has empty body so no data binding is performed. 
Fortunately manual steps are deadly easy: 
- start my example project
- go to server:port/SWF-1566/myflow.html 
  - fill any value in any inputs
  - open firebug/chrome inspector
  - modify index within any input name, like from elements[0].a to elements[10000].a 
  - click next
  - on a page you should see that a given number of rows has been created- to reflect creation a dedicated bean for each row. 

So as i stated in original jira issue: if malicious user modify your html page before data binding  you could easily end up with a out-of-memory. 

A previous approach to databinding (WebDataBinder) had an extra option to prevent this kind of situation: autoGrowCollectionLimit. Why not use the same/similar mechanism for https://github.com/SpringSource/spring-framework/blob/master/spring-expression/src/main/java/org/springframework/expression/spel/SpelParserConfiguration.java
