### PR TITLE
URL Cleanup

### DIFF
--- a/SWF-0000-jsf/pom.xml
+++ b/SWF-0000-jsf/pom.xml
@@ -161,7 +161,7 @@
 		<repository>
 			<id>spring-related-snapshot-releases</id>
 			<name>Latest Spring Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<releases><enabled>false</enabled></releases>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>

--- a/SWF-0000-jsf12/pom.xml
+++ b/SWF-0000-jsf12/pom.xml
@@ -154,13 +154,13 @@
 		<repository>
 			<id>spring-snapshots</id>
 			<name>Spring Snapshots</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 		</repository>
 
 		<repository>
 			<id>spring-dependencies</id>
 			<name>Spring Dependencies</name>
-			<url>http://repo.springsource.org/libs-release</url>
+			<url>https://repo.springsource.org/libs-release</url>
 		</repository>
 
 	</repositories>

--- a/SWF-0000-primefaces/pom.xml
+++ b/SWF-0000-primefaces/pom.xml
@@ -170,7 +170,7 @@
 		<repository>
 			<id>spring-related-snapshot-releases</id>
 			<name>Latest Spring Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<releases><enabled>false</enabled></releases>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
@@ -178,7 +178,7 @@
 		<repository>
 			<id>primefaces-releases</id>
 			<name>Prime Technology Repository</name>
-			<url>http://repository.primefaces.org</url>
+			<url>https://repository.primefaces.org</url>
 			<layout>default</layout>
 		</repository>
 

--- a/SWF-0000-richfaces/pom.xml
+++ b/SWF-0000-richfaces/pom.xml
@@ -173,7 +173,7 @@
 		<repository>
 			<id>spring-related-snapshot-releases</id>
 			<name>Latest Spring Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<releases><enabled>false</enabled></releases>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>

--- a/SWF-0000/pom.xml
+++ b/SWF-0000/pom.xml
@@ -187,7 +187,7 @@
 		<repository>
 			<id>spring-related-snapshot-releases</id>
 			<name>Spring Maven Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<releases><enabled>false</enabled></releases>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
@@ -195,7 +195,7 @@
         <repository>
 			<id>spring-related-milestone-releases</id>
 			<name>Spring Maven Milestone Repository</name>
-			<url>http://maven.springframework.org/milestone</url>
+			<url>https://maven.springframework.org/milestone</url>
 			<snapshots><enabled>false</enabled></snapshots>
 		</repository>
 

--- a/SWF-1468/pom.xml
+++ b/SWF-1468/pom.xml
@@ -161,7 +161,7 @@
 		<repository>
 			<id>spring-related-snapshot-releases</id>
 			<name>Latest Spring Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<releases><enabled>false</enabled></releases>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>

--- a/SWF-1482/pom.xml
+++ b/SWF-1482/pom.xml
@@ -184,7 +184,7 @@
 		<repository>
 			<id>springframework.snapshot</id>
 			<name>Latest Spring Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<releases><enabled>false</enabled></releases>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
@@ -192,7 +192,7 @@
 		<repository>
 			<id>primefaces</id>
 			<name>Prime Technology Repository</name>
-			<url>http://repository.prime.com.tr</url>
+			<url>https://repository.prime.com.tr</url>
 			<layout>default</layout>
 		</repository>
 		

--- a/SWF-1483/pom.xml
+++ b/SWF-1483/pom.xml
@@ -187,7 +187,7 @@
 		<repository>
 			<id>spring-related-snapshot-releases</id>
 			<name>Spring Maven Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<releases><enabled>false</enabled></releases>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
@@ -195,7 +195,7 @@
         <repository>
 			<id>spring-related-milestone-releases</id>
 			<name>Spring Maven Milestone Repository</name>
-			<url>http://maven.springframework.org/milestone</url>
+			<url>https://maven.springframework.org/milestone</url>
 			<snapshots><enabled>false</enabled></snapshots>
 		</repository>
 

--- a/SWF-1495/pom.xml
+++ b/SWF-1495/pom.xml
@@ -187,7 +187,7 @@
 		<repository>
 			<id>spring-related-snapshot-releases</id>
 			<name>Spring Maven Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<releases><enabled>false</enabled></releases>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
@@ -195,7 +195,7 @@
         <repository>
 			<id>spring-related-milestone-releases</id>
 			<name>Spring Maven Milestone Repository</name>
-			<url>http://maven.springframework.org/milestone</url>
+			<url>https://maven.springframework.org/milestone</url>
 			<snapshots><enabled>false</enabled></snapshots>
 		</repository>
 

--- a/SWF-1496/pom.xml
+++ b/SWF-1496/pom.xml
@@ -191,7 +191,7 @@
 		<repository>
 			<id>org.maven.central</id>
 			<name>Maven Central Repository</name>
-			<url>http://repo1.maven.org/maven2/</url>
+			<url>https://repo1.maven.org/maven2/</url>
 			<snapshots><enabled>false</enabled></snapshots>
 		</repository>
 
@@ -199,7 +199,7 @@
 		<repository>
 			<id>org.springframework.maven.snapshot</id>
 			<name>Spring Maven Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<releases><enabled>false</enabled></releases>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
@@ -208,7 +208,7 @@
         <repository>
 			<id>org.springframework.maven.milestone</id>
 			<name>Spring Maven Milestone Repository</name>
-			<url>http://maven.springframework.org/milestone</url>
+			<url>https://maven.springframework.org/milestone</url>
 			<snapshots><enabled>false</enabled></snapshots>
 		</repository>
 

--- a/SWF-1500/booking-faces/pom.xml
+++ b/SWF-1500/booking-faces/pom.xml
@@ -189,14 +189,14 @@
 		<repository>
 			<id>org.maven.central</id>
 			<name>Maven Central Repository</name>
-			<url>http://repo1.maven.org/maven2</url>
+			<url>https://repo1.maven.org/maven2</url>
 			<snapshots><enabled>false</enabled></snapshots>
 		</repository>
 		<!-- For testing against latest Spring snapshots -->
 		<repository>
 			<id>org.springframework.maven.snapshot</id>
 			<name>Spring Maven Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<releases><enabled>false</enabled></releases>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
@@ -204,20 +204,20 @@
         <repository>
 			<id>org.springframework.maven.milestone</id>
 			<name>Spring Maven Milestone Repository</name>
-			<url>http://maven.springframework.org/milestone</url>
+			<url>https://maven.springframework.org/milestone</url>
 			<snapshots><enabled>false</enabled></snapshots>
 		</repository>		
 		<!-- For Mojarra 2.x -->
 		<repository>
 			<id>java.net.release</id>
 			<name>Repository for Projects On Hosted on java.net</name>
-			<url>http://download.java.net/maven/2</url>
+			<url>https://download.java.net/maven/2</url>
 		</repository>
 		<!-- PrimeFaces -->
 		<repository>
 			<id>primefaces</id>
 			<name>Prime Technology Maven Repository</name>
-			<url>http://repository.primefaces.org</url>
+			<url>https://repository.primefaces.org</url>
 			<layout>default</layout>
 		</repository>		
 	</repositories>

--- a/SWF-1500/tmpCheck/pom.xml
+++ b/SWF-1500/tmpCheck/pom.xml
@@ -37,7 +37,7 @@
 		<repository>
 			<id>org.maven.central</id>
 			<name>Maven Central Repository</name>
-			<url>http://repo1.maven.org/maven2</url>
+			<url>https://repo1.maven.org/maven2</url>
 			<snapshots><enabled>false</enabled></snapshots>
 		</repository>
 
@@ -45,7 +45,7 @@
 		<repository>
 			<id>java.net.release</id>
 			<name>Repository for Projects On Hosted on java.net</name>
-			<url>http://download.java.net/maven/2</url>
+			<url>https://download.java.net/maven/2</url>
 		</repository>
 
 	</repositories>

--- a/SWF-1501/pom.xml
+++ b/SWF-1501/pom.xml
@@ -168,7 +168,7 @@
 		<repository>
 			<id>spring-related-snapshot-releases</id>
 			<name>Latest Spring Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<releases><enabled>false</enabled></releases>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
@@ -176,7 +176,7 @@
 		<repository>
 			<id>primefaces-releases</id>
 			<name>Prime Technology Repository</name>
-			<url>http://repository.primefaces.org</url>
+			<url>https://repository.primefaces.org</url>
 			<layout>default</layout>
 		</repository>
 

--- a/SWF-1506/pom.xml
+++ b/SWF-1506/pom.xml
@@ -187,7 +187,7 @@
 		<repository>
 			<id>spring-related-snapshot-releases</id>
 			<name>Spring Maven Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<releases><enabled>false</enabled></releases>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
@@ -195,7 +195,7 @@
         <repository>
 			<id>spring-related-milestone-releases</id>
 			<name>Spring Maven Milestone Repository</name>
-			<url>http://maven.springframework.org/milestone</url>
+			<url>https://maven.springframework.org/milestone</url>
 			<snapshots><enabled>false</enabled></snapshots>
 		</repository>
 

--- a/SWF-1516/pom.xml
+++ b/SWF-1516/pom.xml
@@ -191,7 +191,7 @@
 		<repository>
 			<id>org.maven.central</id>
 			<name>Maven Central Repository</name>
-			<url>http://repo1.maven.org/maven2/</url>
+			<url>https://repo1.maven.org/maven2/</url>
 			<snapshots><enabled>false</enabled></snapshots>
 		</repository>
 
@@ -199,7 +199,7 @@
 		<repository>
 			<id>org.springframework.maven.snapshot</id>
 			<name>Spring Maven Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<releases><enabled>false</enabled></releases>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
@@ -208,7 +208,7 @@
         <repository>
 			<id>org.springframework.maven.milestone</id>
 			<name>Spring Maven Milestone Repository</name>
-			<url>http://maven.springframework.org/milestone</url>
+			<url>https://maven.springframework.org/milestone</url>
 			<snapshots><enabled>false</enabled></snapshots>
 		</repository>
 

--- a/SWF-1525/pom.xml
+++ b/SWF-1525/pom.xml
@@ -219,7 +219,7 @@
 		<repository>
 			<id>spring-related-snapshot-releases</id>
 			<name>Spring Snapshots</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<releases><enabled>false</enabled></releases>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
@@ -227,7 +227,7 @@
 		<repository>
 			<id>spring-related-milestone-releases</id>
 			<name>Spring Milestones</name>
-			<url>http://maven.springframework.org/milestone</url>
+			<url>https://maven.springframework.org/milestone</url>
 			<snapshots><enabled>false</enabled></snapshots>
 		</repository>
 

--- a/SWF-1529/pom.xml
+++ b/SWF-1529/pom.xml
@@ -182,7 +182,7 @@
 		<repository>
 			<id>spring-related-snapshot-releases</id>
 			<name>Latest Spring Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<releases><enabled>false</enabled></releases>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
@@ -190,7 +190,7 @@
 		<repository>
 			<id>primefaces-releases</id>
 			<name>Prime Technology Repository</name>
-			<url>http://repository.primefaces.org</url>
+			<url>https://repository.primefaces.org</url>
 			<layout>default</layout>
 		</repository>
 

--- a/SWF-1544/pom.xml
+++ b/SWF-1544/pom.xml
@@ -161,7 +161,7 @@
 		<repository>
 			<id>spring-related-snapshot-releases</id>
 			<name>Latest Spring Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<releases><enabled>false</enabled></releases>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>

--- a/SWF-1566/pom.xml
+++ b/SWF-1566/pom.xml
@@ -186,7 +186,7 @@
 		<repository>
 			<id>spring-related-snapshot-releases</id>
 			<name>Spring Maven Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<releases><enabled>false</enabled></releases>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
@@ -194,7 +194,7 @@
         <repository>
 			<id>spring-related-milestone-releases</id>
 			<name>Spring Maven Milestone Repository</name>
-			<url>http://maven.springframework.org/milestone</url>
+			<url>https://maven.springframework.org/milestone</url>
 			<snapshots><enabled>false</enabled></snapshots>
 		</repository>
 

--- a/SWF-1571/pom.xml
+++ b/SWF-1571/pom.xml
@@ -144,14 +144,14 @@
 		<repository>
 			<id>org.maven.central</id>
 			<name>Maven Central Repository</name>
-			<url>http://repo1.maven.org/maven2</url>
+			<url>https://repo1.maven.org/maven2</url>
 			<snapshots><enabled>false</enabled></snapshots>
 		</repository>
 		<!-- For testing against latest Spring snapshots -->
 		<repository>
 			<id>org.springframework.maven.snapshot</id>
 			<name>Spring Maven Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<releases><enabled>false</enabled></releases>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
@@ -159,14 +159,14 @@
         <repository>
 			<id>org.springframework.maven.milestone</id>
 			<name>Spring Maven Milestone Repository</name>
-			<url>http://maven.springframework.org/milestone</url>
+			<url>https://maven.springframework.org/milestone</url>
 			<snapshots><enabled>false</enabled></snapshots>
 		</repository>		
 		<!-- For Mojarra 2.x -->
 		<repository>
 			<id>java.net.release</id>
 			<name>Repository for Projects On Hosted on java.net</name>
-			<url>http://download.java.net/maven/2</url>
+			<url>https://download.java.net/maven/2</url>
 		</repository>
 		<repository>
 		  <id>jboss-public-repository-group</id>

--- a/SWF-1572/pom.xml
+++ b/SWF-1572/pom.xml
@@ -188,7 +188,7 @@
 		<repository>
 			<id>spring-related-snapshot-releases</id>
 			<name>Spring Maven Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<releases><enabled>false</enabled></releases>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
@@ -196,7 +196,7 @@
         <repository>
 			<id>spring-related-milestone-releases</id>
 			<name>Spring Maven Milestone Repository</name>
-			<url>http://maven.springframework.org/milestone</url>
+			<url>https://maven.springframework.org/milestone</url>
 			<snapshots><enabled>false</enabled></snapshots>
 		</repository>
 

--- a/SWF-1577/pom.xml
+++ b/SWF-1577/pom.xml
@@ -161,7 +161,7 @@
 		<repository>
 			<id>spring-related-snapshot-releases</id>
 			<name>Latest Spring Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<releases><enabled>false</enabled></releases>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>

--- a/SWF-1630/pom.xml
+++ b/SWF-1630/pom.xml
@@ -189,7 +189,7 @@
 		<repository>
 			<id>spring-related-snapshot-releases</id>
 			<name>Latest Spring Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<releases><enabled>false</enabled></releases>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>

--- a/SWF-1631/pom.xml
+++ b/SWF-1631/pom.xml
@@ -160,7 +160,7 @@
       <repository>
          <id>springsource</id>
          <name>SpringSource Repository</name>
-         <url>http://repo.springsource.org/milestone</url>
+         <url>https://repo.springsource.org/milestone</url>
          <releases>
             <enabled>true</enabled>
          </releases>
@@ -179,7 +179,7 @@
       <repository>
          <id>java.net</id>
          <name>Java.net Repository</name>
-         <url>http://download.java.net/maven/2/</url>
+         <url>https://download.java.net/maven/2/</url>
          <snapshots>
             <enabled>false</enabled>
          </snapshots>
@@ -187,7 +187,7 @@
       <repository>
          <id>primefaces</id>
          <name>Prime Technology Repository</name>
-         <url>http://repository.primefaces.org</url>
+         <url>https://repository.primefaces.org</url>
          <layout>default</layout>
       </repository>
    </repositories>

--- a/SWF-1639/pom.xml
+++ b/SWF-1639/pom.xml
@@ -15,7 +15,7 @@
 		<repository>
 			<id>prime-repo</id>
 			<name>PrimeFaces Maven Repository</name>
-			<url>http://repository.primefaces.org</url>
+			<url>https://repository.primefaces.org</url>
 			<layout>default</layout>
 		</repository>
 	</repositories>

--- a/SWF-1662/pom.xml
+++ b/SWF-1662/pom.xml
@@ -187,7 +187,7 @@
 		<repository>
 			<id>spring-related-snapshot-releases</id>
 			<name>Spring Maven Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<releases><enabled>false</enabled></releases>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
@@ -195,7 +195,7 @@
         <repository>
 			<id>spring-related-milestone-releases</id>
 			<name>Spring Maven Milestone Repository</name>
-			<url>http://maven.springframework.org/milestone</url>
+			<url>https://maven.springframework.org/milestone</url>
 			<snapshots><enabled>false</enabled></snapshots>
 		</repository>
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://repository.prime.com.tr (UnknownHostException) migrated to:  
  https://repository.prime.com.tr ([https](https://repository.prime.com.tr) result UnknownHostException).
* http://download.java.net/maven/2 (301) migrated to:  
  https://download.java.net/maven/2 ([https](https://download.java.net/maven/2) result 404).
* http://download.java.net/maven/2/ (301) migrated to:  
  https://download.java.net/maven/2/ ([https](https://download.java.net/maven/2/) result 404).

## Fixed Success 
These URLs were fixed successfully.

* http://repo1.maven.org/maven2/ migrated to:  
  https://repo1.maven.org/maven2/ ([https](https://repo1.maven.org/maven2/) result 200).
* http://repository.primefaces.org migrated to:  
  https://repository.primefaces.org ([https](https://repository.primefaces.org) result 200).
* http://repo.springsource.org/libs-release migrated to:  
  https://repo.springsource.org/libs-release ([https](https://repo.springsource.org/libs-release) result 301).
* http://repo.springsource.org/milestone migrated to:  
  https://repo.springsource.org/milestone ([https](https://repo.springsource.org/milestone) result 301).
* http://repo.springsource.org/snapshot migrated to:  
  https://repo.springsource.org/snapshot ([https](https://repo.springsource.org/snapshot) result 301).
* http://maven.springframework.org/milestone migrated to:  
  https://maven.springframework.org/milestone ([https](https://maven.springframework.org/milestone) result 302).
* http://maven.springframework.org/snapshot migrated to:  
  https://maven.springframework.org/snapshot ([https](https://maven.springframework.org/snapshot) result 302).
* http://repo1.maven.org/maven2 migrated to:  
  https://repo1.maven.org/maven2 ([https](https://repo1.maven.org/maven2) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/maven-v4_0_0.xsd
* http://maven.apache.org/xsd/maven-4.0.0.xsd
* http://www.w3.org/2001/XMLSchema-instance